### PR TITLE
Preserve Recipients

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ CakePHP uses [profiles and transports](http://book.cakephp.org/3.0/en/core-libra
             'emailFormat' => 'both',
             'from' => ['you@yours.com' => 'Bob Bobbington'],
             'sender' => ['you@yours.com' => 'Bob Bobbington'],
-            'Mandrill' => [] // Don't ask, the plugin needs/wants this empty array
+            'Mandrill' => [
+                'preserve_recipients' => true
+            ]
         ]
     ],
     'EmailTransport' => [

--- a/src/Network/Email/MandrillTransport.php
+++ b/src/Network/Email/MandrillTransport.php
@@ -99,7 +99,9 @@ class MandrillTransport extends AbstractTransport
                 ];
             }
         }
-
+        if ($this->config('Mandrill.preserve_recipients')) {
+            $message['preserve_recipients'] = true;
+        }
         // Attachments
         $message = $this->_attachments($email, $message);
 


### PR DESCRIPTION
This pull will add the option to specify in the config if when cc'ing emails you would like to preserve the recipients and allow for reply-all 
[http://blog.mandrill.com/rules-options-easier-bcc.htm](http://blog.mandrill.com/rules-options-easier-bcc.html)